### PR TITLE
Distribute pip-compatible archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Build directory
 build/
+dist/
+*.egg-info/
+
 # =========================
 # Operating System Files
 # =========================

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md LICENSE CMakeLists.txt
+recursive-include src *

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,37 +20,28 @@ environment:
 
 install:
   - ps: (New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/Ortham/ci-scripts/2.0.0/delete_old_bintray_versions.py', "$env:APPVEYOR_BUILD_FOLDER\delete_old_bintray_versions.py")
+  - ps: $env:PYTHON_VERSION_ARCH = $env:PYTHON_VERSION + "-" + $env:PLATFORM.substring($env:PLATFORM.length - 2)
+  - echo Choosing Python %PYTHON_VERSION_ARCH%
+  - py -%PYTHON_VERSION_ARCH% -m pip install wheel
 
-before_build:
-  - ps: $env:PYTHON_DIRECTORY_VERSION=$env:PYTHON_VERSION.Replace(".", "")
+build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - ps: mkdir build
-  - cd build
-  - ps: |
-      if ($env:PLATFORM -eq 'Win32') {
-        cmake .. -G "Visual Studio 15 2017" -DPYTHON_EXECUTABLE="C:\Python${env:PYTHON_DIRECTORY_VERSION}\python.exe"
-      } else {
-        cmake .. -G "Visual Studio 15 2017" -A x64 -DPYTHON_EXECUTABLE="C:\Python${env:PYTHON_DIRECTORY_VERSION}-x64\python.exe"
-      }
+  - py -%PYTHON_VERSION_ARCH% ./setup.py sdist bdist_wheel
 
-build:
-  verbosity: minimal
-  project: 'c:\projects\loot-api-python\build\loot_api_python.sln'
+before_test:
+  - ps: py -$env:PYTHON_VERSION_ARCH -m pip install (get-item .\dist\*.whl)
 
 test_script:
-  - cd %APPVEYOR_BUILD_FOLDER%\build
-  - ctest -C %CONFIGURATION%
+  - py -%PYTHON_VERSION_ARCH% ./test/test.py
 
 after_test:
-  - cd %APPVEYOR_BUILD_FOLDER%\build
-  - cpack -C %CONFIGURATION%
-  # AppVeyor checks out a specific commit, but that means the archive script
-  # can't tell which branch it's on, so rename the 7z archives.
   - ps: $env:GIT_DESCRIBE = ((git describe --tags --long --always) | Out-String) -replace "`n|`r", ""
 
 artifacts:
-  - path: build\package\loot_api_python-$(GIT_DESCRIBE)_$(APPVEYOR_REPO_BRANCH)-python$(PYTHON_VERSION)-win$(ARCHITECTURE).7z
-    name: loot_api_python
+  - path: 'dist/*.whl'
+    name: wheel
+  - path: 'dist/*.tar.gz'
+    name: source
 
 deploy:
   - provider: BinTray
@@ -62,7 +53,19 @@ deploy:
     package: loot-api-python
     version: $(GIT_DESCRIBE)_$(APPVEYOR_REPO_BRANCH)
     publish: true
-    artifact: loot_api_python
+    artifact: wheel
+
+  - provider: BinTray
+    username: wrinklyninja
+    api_key:
+      secure: PgsEA6TjHVf718zMnK7J/fT1hUAVNKBeWhpYgYaeCyeZk37VT4Ics6j7+B7ElLEr
+    subject: loot
+    repo: snapshots
+    package: loot-api-python
+    version: $(GIT_DESCRIBE)_$(APPVEYOR_REPO_BRANCH)
+    publish: true
+    override: true
+    artifact: source
 
   - provider: GitHub
     tag: $(APPVEYOR_REPO_TAG_NAME)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,8 @@ build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
   - py -%PYTHON_VERSION_ARCH% ./setup.py sdist bdist_wheel
 
-before_test:
-  - ps: py -$env:PYTHON_VERSION_ARCH -m pip install (get-item .\dist\*.whl)
+# before_test:
+#   - ps: py -$env:PYTHON_VERSION_ARCH -m pip install (get-item .\dist\*.whl)
 
 test_script:
   - py -%PYTHON_VERSION_ARCH% ./test/test.py

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,88 @@
+# This was created following the example at
+# <https://github.com/pybind/cmake_example>
+
+import os
+import re
+import sys
+import platform
+import subprocess
+
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
+from distutils.version import LooseVersion
+
+
+class CMakeExtension(Extension):
+    def __init__(self, name, sourcedir=''):
+        Extension.__init__(self, name, sources=[])
+        self.sourcedir = os.path.abspath(sourcedir)
+
+
+class CMakeBuild(build_ext):
+    def run(self):
+        try:
+            out = subprocess.check_output(['cmake', '--version'])
+        except OSError:
+            raise RuntimeError("CMake must be installed to build the following extensions: " +
+                               ", ".join(e.name for e in self.extensions))
+
+        if platform.system() == "Windows":
+            cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
+            if cmake_version < '3.1.0':
+                raise RuntimeError("CMake >= 3.1.0 is required on Windows")
+
+        for ext in self.extensions:
+            self.build_extension(ext)
+
+    def build_extension(self, ext):
+        extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+        cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
+                      '-DPYTHON_EXECUTABLE=' + sys.executable]
+
+        if platform.system() == "Windows":
+            cfg = 'Debug' if self.debug else 'RelWithDebInfo'
+            cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
+            if sys.maxsize > 2**32:
+                cmake_args += ['-A', 'x64']
+            build_args = ['--config', cfg, '--', '/m']
+        else:
+            cfg = 'Debug' if self.debug else 'Release'
+            cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
+            build_args += ['--config', cfg, '--', '-j2']
+
+        env = os.environ.copy()
+        env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
+                                                              self.distribution.get_version())
+        if not os.path.exists(self.build_temp):
+            os.makedirs(self.build_temp)
+        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
+        subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setup(
+    name='libloot-python',
+    version='4.0.2',
+    author='Oliver Hamlet',
+    author_email='oliber.hamlet@gmail.com',
+    description='A Python module that wraps libloot.',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/loot/loot-api-python",
+    ext_modules=[CMakeExtension('libloot-python')],
+    cmdclass=dict(build_ext=CMakeBuild),
+    zip_safe=False,
+    classifiers=[
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: C++'
+        'Operating System :: Microsoft :: Windows',
+        'Intended Audience :: Developers',
+    ],
+    python_requires='>=2.7',
+    data_files=[
+        ('.', ['README.md'])
+    ]
+)


### PR DESCRIPTION
This follows on from #11 but takes a slightly different approach.

It currently builds the archives but pip thinks the package is already installed when run on AppVeyor, and after installing locally pip uninstall thinks there's nothing to uninstall. It also dumps the binaries into the `site-packages` root directory, which doesn't seem right. I'd also like to include the README.md in the archives but haven't figured out how to do that (and I've got no idea how it knows to package the binaries, it's magic to me).

This setup.py also doesn't handle installing the MSVC redist, I plan to address that once the basic usage has been sorted out.